### PR TITLE
Add n8n-setup skill and update CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,200 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+n8n-mcp-server is an MCP (Model Context Protocol) server providing 9 tools to interact with the n8n workflow automation platform at n8n.homelab.com. Built with FastMCP and Python 3.11+, it enables Claude Code to manage workflows (CRUD operations), execute workflows, and monitor execution history.
+
+## **CRITICAL: Development vs Staging**
+
+**THIS IS THE DEVELOPMENT DIRECTORY** - `/home/kviscount.adm@homelab.com/projects/n8n-mcp-server/`
+
+**ALWAYS create/modify source files HERE**, including:
+- Source code in `src/`
+- Skills in `skills/`
+- Commands in `commands/` (if created)
+- Tests in `tests/`
+- Documentation files
+
+**NEVER create files directly in the staging directory:**
+- Staging location: `/home/kviscount.adm@homelab.com/projects/claude-marketplace/plugins/n8n-api/`
+- Files are COPIED to staging during build/deploy
+- Staging is read-only from development perspective
+
+**Workflow:**
+1. Create/modify files in THIS directory (development)
+2. Test and validate changes here
+3. Copy to staging directory for deployment (manual or via build process)
+
+## Development Commands
+
+### Testing
+```bash
+# Run all tests
+pytest
+
+# Run with coverage report
+pytest --cov=n8n_mcp --cov-report=term-missing
+
+# Run specific test file
+pytest tests/test_server.py -v
+```
+
+### Code Quality (run before committing)
+```bash
+# Format code (line-length: 100)
+black src tests
+
+# Lint code
+ruff check src tests
+
+# Type check (strict mode)
+mypy src
+```
+
+### Development Setup
+```bash
+# Create virtual environment and install
+uv venv
+source .venv/bin/activate  # or .venv\Scripts\activate on Windows
+uv pip install -e ".[dev]"
+
+# Configure environment
+cp .env.example .env
+# Edit .env with your N8N_API_KEY
+```
+
+### Running the Server
+```bash
+# Direct execution
+python -m n8n_mcp.server
+
+# Register with Claude Code
+claude mcp add n8n-api \
+  --env N8N_BASE_URL=https://n8n.homelab.com \
+  --env N8N_API_KEY=your_key_here \
+  --scope user -- \
+  python -m n8n_mcp.server
+```
+
+## Architecture
+
+### Core Components
+
+**src/n8n_mcp/server.py** - FastMCP server entry point
+- Defines 9 MCP tools decorated with `@mcp.tool()` and `@handle_errors`
+- Loads `.env` from plugin directory (not cwd) to support installed plugin usage
+- Module-level `N8nClient` instance for efficiency
+- Tools: list_workflows, get_workflow, create_workflow, update_workflow, delete_workflow, activate_workflow, execute_workflow, get_executions, get_execution
+
+**src/n8n_mcp/client.py** - N8nClient class
+- Async context manager (`async with`) wrapping httpx for n8n REST API
+- Methods mirror the 9 MCP tools
+- SSL verification disabled (`verify_ssl=False`) for homelab environments
+- Proper cleanup in `__aexit__` and `close()`
+
+**Architecture Pattern**: FastMCP tools → N8nClient methods → httpx HTTP calls → n8n API
+
+### Environment Variables
+- `N8N_BASE_URL`: n8n instance URL (default: https://n8n.homelab.com)
+- `N8N_API_KEY`: Required user API token from n8n
+
+**CRITICAL**: Environment is loaded from plugin directory (`_plugin_dir = Path(__file__).resolve().parent.parent.parent`), not current working directory, to support installed plugin usage.
+
+## Code Style
+
+### Type Hints (Strict Mode)
+```python
+# All functions must have complete type hints
+async def list_workflows() -> dict[str, Any]:
+    """List all workflows from n8n.
+
+    Returns:
+        Dictionary containing workflows data from n8n API
+    """
+```
+
+### Formatting Standards
+- **Line length**: 100 characters (black + ruff)
+- **Target**: Python 3.11
+- **Imports**: Sorted by ruff
+- **Naming**: snake_case (functions), PascalCase (classes), UPPER_SNAKE_CASE (constants)
+
+### Special Rules
+- `src/n8n_mcp/models.py`: mixedCase allowed for n8n API field names (ruff ignore N815)
+- All MCP tools use `@handle_errors` decorator for consistent error handling
+- Async/await required for all API operations
+
+## Testing Requirements
+
+- New features require tests in `tests/test_server.py`
+- Use pytest with async support (`asyncio_mode = "auto"`)
+- Maintain or improve coverage (currently comprehensive)
+- Mock n8n API responses using pytest fixtures
+
+## Common Patterns
+
+### Adding a New MCP Tool
+1. Add method to `N8nClient` class in `client.py`
+2. Add tool function in `server.py` with `@mcp.tool()` and `@handle_errors`
+3. Add comprehensive tests in `tests/test_server.py`
+4. Update README.md tool list
+5. Run: `black src tests && ruff check src tests && mypy src && pytest`
+
+### Environment Loading
+The `.env` file is loaded from the plugin directory, not cwd:
+```python
+_plugin_dir = Path(__file__).resolve().parent.parent.parent
+load_dotenv(_plugin_dir / ".env")
+```
+This ensures the server works when installed as a Claude Code plugin.
+
+### Error Handling
+Use the `@handle_errors` decorator on all MCP tools:
+```python
+@mcp.tool()
+@handle_errors
+async def my_tool() -> dict[str, Any]:
+    """Tool description."""
+    return await client.my_method()
+```
+
+## Plugin Staging Directory
+
+**Location**: `/home/kviscount.adm@homelab.com/projects/claude-marketplace/plugins/n8n-api/`
+
+**IMPORTANT**: This is the DEPLOYMENT/STAGING directory. Files are copied here from the development directory.
+
+The staging directory contains:
+- `.claude-plugin/plugin.json` - Plugin metadata
+- `.mcp.json` - MCP server configuration
+- `src/` - Source code (copied from development)
+- `skills/` - Skills (copied from development)
+- `commands/` - Commands (copied from development)
+
+**To update staging:**
+1. Make changes in THIS development directory first
+2. Copy updated files to staging directory
+3. Test the plugin from staging
+
+**NEVER:**
+- Create new files directly in staging
+- Edit files in staging without updating development first
+- Use staging as the source of truth
+
+## Git Workflow
+
+**CRITICAL**: Per user's global CLAUDE.md:
+- Use `git switch` (NOT `git checkout`) for branch operations
+- NEVER `git push` to main
+- Source control must be maintained in project directory
+
+## n8n API Integration
+
+Compatible with n8n REST API v1. Supported endpoints:
+- GET/POST/PUT/DELETE/PATCH `/api/v1/workflows`
+- POST `/api/v1/workflows/{id}/execute`
+- GET `/api/v1/executions`
+
+See `N8N_API_WORKFLOW_CREATION_REPORT.md` for detailed API research.

--- a/skills/n8n-setup/SKILL.md
+++ b/skills/n8n-setup/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: n8n-setup
+description: |
+  Configure n8n MCP server connection credentials (API key and base URL).
+  Use when the user needs to set up or update their n8n API credentials.
+---
+
+# n8n Setup Skill
+
+Guide users through configuring their n8n API credentials for the MCP server.
+
+## When to Use
+
+- User mentions setting up n8n
+- User asks how to configure n8n credentials
+- User reports authentication errors with n8n
+- User needs to change their n8n instance URL or API key
+
+## Setup Process
+
+### 1. Collect Required Information
+
+Ask the user for:
+- **n8n Base URL**: The full URL of their n8n instance (e.g., `https://n8n.homelab.com`)
+- **n8n API Key**: Their n8n API key from Settings > API
+
+### 2. Create/Update .env File
+
+Create or update the `.env` file in the plugin root directory with:
+
+```
+N8N_BASE_URL=<user's n8n URL>
+N8N_API_KEY=<user's API key>
+```
+
+**Location**: `${CLAUDE_PLUGIN_ROOT}/.env`
+
+### 3. Verify and Restart
+
+After configuration:
+1. Inform user the credentials have been saved
+2. Remind them to restart Claude Code
+3. Suggest testing with: "List my n8n workflows"
+
+## Example Interaction
+
+**User**: "How do I set up n8n?"
+
+**Assistant**: "I'll help you configure the n8n MCP server. I need two pieces of information:
+
+1. **n8n Instance URL**: What's your n8n base URL? (e.g., https://n8n.homelab.com)
+2. **API Key**: What's your n8n API key? You can get this from n8n under Settings > API > Create API Key
+
+Please provide these details."
+
+**User**: "URL is https://n8n.homelab.com and key is n8n_api_abc123xyz..."
+
+**Assistant**:
+*[Creates/updates .env file at ${CLAUDE_PLUGIN_ROOT}/.env]*
+
+"✓ Configuration saved!
+
+**Next steps:**
+1. Restart Claude Code for changes to take effect
+2. Test the connection: 'List my n8n workflows'
+
+Your n8n instance at https://n8n.homelab.com is now configured."
+
+## Getting an API Key
+
+Guide users to get their API key:
+1. Log into their n8n instance
+2. Go to Settings > API
+3. Click "Create API Key"
+4. Copy the generated key (they won't be able to see it again)
+
+## Security Notes
+
+- Credentials are stored in `.env` (not committed to git)
+- API keys should be kept secure and never shared
+- If compromised, user should regenerate the key in n8n
+- To update credentials, simply re-run this setup process
+
+## Troubleshooting
+
+**401 Unauthorized**: API key is invalid or expired
+- Verify the key is correct
+- Regenerate key in n8n if needed
+
+**Connection refused**: Cannot reach n8n instance
+- Verify the base URL is correct
+- Check network connectivity
+- Ensure n8n instance is running


### PR DESCRIPTION
## Summary
- Add `skills/n8n-setup/SKILL.md` for interactive credential configuration
- Update `CLAUDE.md` with critical development vs staging workflow documentation
- Document proper file creation locations and deployment process

## Changes
1. **New skill: `/n8n-setup`** - Guides users through configuring n8n API credentials (base URL and API key)
2. **CLAUDE.md updates** - Added critical section about development vs staging workflow to prevent creating files in wrong locations

## Testing
- Skill created in development directory (`skills/n8n-setup/`)
- Ready to be copied to staging for deployment

## Version
- Auto-bumped to 0.1.2