### PR TITLE
feat: Phase 2 - Workflow filtering, validation, and credential docs

### DIFF
--- a/docs/CREDENTIAL_TYPES.md
+++ b/docs/CREDENTIAL_TYPES.md
@@ -1,0 +1,421 @@
+# n8n Credential Types Reference
+
+This document lists common credential types used in n8n workflows with their required fields and usage examples.
+
+## Using Credentials
+
+### Always Use Credential IDs
+
+When creating workflows, **always reference credentials by ID** rather than name:
+
+```json
+// CORRECT - Use credential ID
+"credentials": {
+  "githubApi": {
+    "id": "cred_abc123",
+    "name": "My GitHub Token"
+  }
+}
+
+// INCORRECT - Name only (unreliable)
+"credentials": {
+  "githubApi": {
+    "name": "My GitHub Token"
+  }
+}
+```
+
+### Discovering Credential IDs
+
+Use the `list_credentials` tool to find existing credential IDs:
+
+```python
+result = await list_credentials()
+# Returns: {"data": [{"id": "cred_123", "name": "GitHub API", "type": "githubApi"}, ...]}
+```
+
+---
+
+## Common Credential Types
+
+### API Key Based
+
+#### `httpHeaderAuth`
+HTTP Header Authentication - Generic API key in header.
+
+```json
+{
+  "name": "My API Key",
+  "type": "httpHeaderAuth",
+  "data": {
+    "name": "X-API-Key",
+    "value": "your-api-key-here"
+  }
+}
+```
+
+#### `httpQueryAuth`
+Query Parameter Authentication - API key as URL parameter.
+
+```json
+{
+  "name": "Query API Key",
+  "type": "httpQueryAuth",
+  "data": {
+    "name": "api_key",
+    "value": "your-api-key-here"
+  }
+}
+```
+
+---
+
+### OAuth2
+
+#### `oAuth2Api`
+Generic OAuth2 credentials.
+
+```json
+{
+  "name": "OAuth2 App",
+  "type": "oAuth2Api",
+  "data": {
+    "clientId": "your-client-id",
+    "clientSecret": "your-client-secret",
+    "accessTokenUrl": "https://api.example.com/oauth/token",
+    "authUrl": "https://api.example.com/oauth/authorize",
+    "scope": "read write"
+  }
+}
+```
+
+---
+
+### Basic Authentication
+
+#### `httpBasicAuth`
+HTTP Basic Authentication (username/password).
+
+```json
+{
+  "name": "Basic Auth",
+  "type": "httpBasicAuth",
+  "data": {
+    "user": "username",
+    "password": "password"
+  }
+}
+```
+
+#### `httpDigestAuth`
+HTTP Digest Authentication.
+
+```json
+{
+  "name": "Digest Auth",
+  "type": "httpDigestAuth",
+  "data": {
+    "user": "username",
+    "password": "password"
+  }
+}
+```
+
+---
+
+### SSH & Server Access
+
+#### `sshPassword`
+SSH with password authentication.
+
+```json
+{
+  "name": "SSH Password",
+  "type": "sshPassword",
+  "data": {
+    "host": "server.example.com",
+    "port": 22,
+    "username": "user",
+    "password": "password"
+  }
+}
+```
+
+#### `sshPrivateKey`
+SSH with private key authentication.
+
+```json
+{
+  "name": "SSH Key",
+  "type": "sshPrivateKey",
+  "data": {
+    "host": "server.example.com",
+    "port": 22,
+    "username": "user",
+    "privateKey": "-----BEGIN RSA PRIVATE KEY-----\n...\n-----END RSA PRIVATE KEY-----",
+    "passphrase": "optional-passphrase"
+  }
+}
+```
+
+---
+
+### Popular Services
+
+#### `githubApi`
+GitHub Personal Access Token or OAuth App.
+
+```json
+{
+  "name": "GitHub",
+  "type": "githubApi",
+  "data": {
+    "accessToken": "ghp_xxxxxxxxxxxx"
+  }
+}
+```
+
+#### `slackApi`
+Slack Bot Token.
+
+```json
+{
+  "name": "Slack Bot",
+  "type": "slackApi",
+  "data": {
+    "accessToken": "xoxb-xxxxxxxxxxxx"
+  }
+}
+```
+
+#### `slackOAuth2Api`
+Slack OAuth2 credentials.
+
+```json
+{
+  "name": "Slack OAuth",
+  "type": "slackOAuth2Api",
+  "data": {
+    "clientId": "your-client-id",
+    "clientSecret": "your-client-secret"
+  }
+}
+```
+
+#### `discordApi`
+Discord Bot Token.
+
+```json
+{
+  "name": "Discord Bot",
+  "type": "discordApi",
+  "data": {
+    "botToken": "your-bot-token"
+  }
+}
+```
+
+#### `telegramApi`
+Telegram Bot Token.
+
+```json
+{
+  "name": "Telegram Bot",
+  "type": "telegramApi",
+  "data": {
+    "accessToken": "your-bot-token"
+  }
+}
+```
+
+---
+
+### Email Services
+
+#### `smtpImap`
+SMTP/IMAP email server credentials.
+
+```json
+{
+  "name": "Email Server",
+  "type": "smtpImap",
+  "data": {
+    "user": "user@example.com",
+    "password": "password",
+    "host": "smtp.example.com",
+    "port": 587,
+    "secure": true
+  }
+}
+```
+
+#### `gmailOAuth2`
+Gmail OAuth2 credentials.
+
+```json
+{
+  "name": "Gmail",
+  "type": "gmailOAuth2",
+  "data": {
+    "clientId": "your-client-id",
+    "clientSecret": "your-client-secret"
+  }
+}
+```
+
+---
+
+### Cloud Providers
+
+#### `awsApi`
+AWS Access Key credentials.
+
+```json
+{
+  "name": "AWS",
+  "type": "awsApi",
+  "data": {
+    "accessKeyId": "AKIAIOSFODNN7EXAMPLE",
+    "secretAccessKey": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+    "region": "us-east-1"
+  }
+}
+```
+
+#### `googleApi`
+Google Service Account credentials.
+
+```json
+{
+  "name": "Google Service Account",
+  "type": "googleApi",
+  "data": {
+    "email": "service-account@project.iam.gserviceaccount.com",
+    "privateKey": "-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----"
+  }
+}
+```
+
+#### `azureApi`
+Azure credentials.
+
+```json
+{
+  "name": "Azure",
+  "type": "azureApi",
+  "data": {
+    "clientId": "your-client-id",
+    "clientSecret": "your-client-secret",
+    "tenantId": "your-tenant-id"
+  }
+}
+```
+
+---
+
+### Databases
+
+#### `postgresApi`
+PostgreSQL database credentials.
+
+```json
+{
+  "name": "PostgreSQL",
+  "type": "postgresApi",
+  "data": {
+    "host": "localhost",
+    "port": 5432,
+    "database": "mydb",
+    "user": "postgres",
+    "password": "password",
+    "ssl": false
+  }
+}
+```
+
+#### `mysqlApi`
+MySQL database credentials.
+
+```json
+{
+  "name": "MySQL",
+  "type": "mysqlApi",
+  "data": {
+    "host": "localhost",
+    "port": 3306,
+    "database": "mydb",
+    "user": "root",
+    "password": "password"
+  }
+}
+```
+
+#### `mongoDbApi`
+MongoDB credentials.
+
+```json
+{
+  "name": "MongoDB",
+  "type": "mongoDbApi",
+  "data": {
+    "connectionString": "mongodb://user:pass@localhost:27017/mydb"
+  }
+}
+```
+
+#### `redisApi`
+Redis credentials.
+
+```json
+{
+  "name": "Redis",
+  "type": "redisApi",
+  "data": {
+    "host": "localhost",
+    "port": 6379,
+    "password": "optional-password"
+  }
+}
+```
+
+---
+
+### Webhooks & APIs
+
+#### `webhookAuth`
+Webhook authentication credentials.
+
+```json
+{
+  "name": "Webhook Auth",
+  "type": "webhookAuth",
+  "data": {
+    "httpMethod": "headerAuth",
+    "headerName": "X-Webhook-Secret",
+    "headerValue": "your-secret"
+  }
+}
+```
+
+---
+
+## Getting Schema for a Credential Type
+
+Use `get_credential_schema` to discover the exact fields required for any credential type:
+
+```python
+schema = await get_credential_schema("githubApi")
+# Returns the JSON schema defining required and optional fields
+```
+
+This is useful when working with credential types not listed in this document.
+
+---
+
+## Security Notes
+
+1. **Never store credentials in workflow definitions** - Use credential references instead
+2. **Use environment variables** for sensitive data in n8n configuration
+3. **Credential data is redacted** in API responses (only id, name, type returned)
+4. **Rotate credentials regularly** - Update through the n8n UI or `update_credential` tool
+5. **Use least-privilege tokens** - Only grant permissions the workflow needs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ packages = ["src/n8n_mcp"]
 
 [project]
 name = "n8n-mcp-server"
-version = "0.4.3"
+version = "0.5.0"
 description = "MCP server providing tools to interact with n8n workflow automation platform"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/n8n_mcp/__init__.py
+++ b/src/n8n_mcp/__init__.py
@@ -5,4 +5,4 @@ Version: 0.1.0
 Created: 2025-11-20
 """
 
-__version__ = "0.4.3"
+__version__ = "0.5.0"

--- a/src/n8n_mcp/validator.py
+++ b/src/n8n_mcp/validator.py
@@ -1,0 +1,206 @@
+"""
+Workflow validation utilities for n8n MCP server.
+
+Validates workflow definitions against n8n API requirements before submission,
+catching common errors early with clear, actionable messages.
+
+Version: 0.1.0
+Created: 2026-01-13
+"""
+
+from typing import Any
+
+# Fields that n8n API rejects in workflow creation/update requests
+FORBIDDEN_FIELDS = frozenset(
+    {
+        "active",
+        "createdAt",
+        "description",
+        "id",
+        "meta",
+        "pinData",
+        "staticData",
+        "triggerCount",
+        "updatedAt",
+        "versionCounter",
+        "versionId",
+    }
+)
+
+# Required fields at workflow root level
+REQUIRED_WORKFLOW_FIELDS = frozenset({"name", "nodes", "connections"})
+
+# Required fields for each node in the nodes array
+REQUIRED_NODE_FIELDS = frozenset({"id", "name", "type", "typeVersion", "position"})
+
+
+class ValidationResult:
+    """Container for validation results with errors and warnings."""
+
+    def __init__(self) -> None:
+        self.errors: list[str] = []
+        self.warnings: list[str] = []
+
+    def add_error(self, message: str) -> None:
+        """Add a validation error (will cause API rejection)."""
+        self.errors.append(message)
+
+    def add_warning(self, message: str) -> None:
+        """Add a validation warning (may cause issues)."""
+        self.warnings.append(message)
+
+    @property
+    def is_valid(self) -> bool:
+        """Check if validation passed (no errors)."""
+        return len(self.errors) == 0
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for MCP response."""
+        return {
+            "valid": self.is_valid,
+            "errors": self.errors,
+            "warnings": self.warnings,
+            "error_count": len(self.errors),
+            "warning_count": len(self.warnings),
+        }
+
+
+def validate_workflow(workflow: dict[str, Any]) -> ValidationResult:
+    """Validate a workflow definition against n8n API requirements.
+
+    Performs comprehensive validation including:
+    - Required field checks
+    - Forbidden field detection
+    - Node structure validation
+    - Connection reference validation
+
+    Args:
+        workflow: Workflow definition dictionary
+
+    Returns:
+        ValidationResult with errors and warnings
+    """
+    result = ValidationResult()
+
+    # Check for forbidden fields
+    _check_forbidden_fields(workflow, result)
+
+    # Check for required fields
+    _check_required_fields(workflow, result)
+
+    # Validate nodes array
+    _validate_nodes(workflow, result)
+
+    # Validate connections reference existing nodes
+    _validate_connections(workflow, result)
+
+    # Check for recommended settings
+    _check_recommended_settings(workflow, result)
+
+    return result
+
+
+def _check_forbidden_fields(workflow: dict[str, Any], result: ValidationResult) -> None:
+    """Check for fields that will cause API rejection."""
+    present_forbidden = set(workflow.keys()) & FORBIDDEN_FIELDS
+    for field in sorted(present_forbidden):
+        result.add_error(
+            f"Forbidden field '{field}' present. "
+            f"Remove it to avoid 'must NOT have additional properties' error."
+        )
+
+
+def _check_required_fields(workflow: dict[str, Any], result: ValidationResult) -> None:
+    """Check for required workflow fields."""
+    missing = REQUIRED_WORKFLOW_FIELDS - set(workflow.keys())
+    for field in sorted(missing):
+        result.add_error(f"Required field '{field}' is missing.")
+
+
+def _validate_nodes(workflow: dict[str, Any], result: ValidationResult) -> None:
+    """Validate the nodes array structure."""
+    nodes = workflow.get("nodes")
+
+    if nodes is None:
+        return  # Already reported as missing required field
+
+    if not isinstance(nodes, list):
+        result.add_error("Field 'nodes' must be an array.")
+        return
+
+    if len(nodes) == 0:
+        result.add_warning("Workflow has no nodes. Consider adding at least a trigger node.")
+        return
+
+    node_ids: set[str] = set()
+    for i, node in enumerate(nodes):
+        if not isinstance(node, dict):
+            result.add_error(f"Node at index {i} must be an object, got {type(node).__name__}.")
+            continue
+
+        # Check required node fields
+        missing_node_fields = REQUIRED_NODE_FIELDS - set(node.keys())
+        for field in sorted(missing_node_fields):
+            result.add_error(
+                f"Node '{node.get('name', f'index {i}')}' missing required field '{field}'."
+            )
+
+        # Track node IDs for connection validation
+        node_id = node.get("id")
+        if node_id:
+            if node_id in node_ids:
+                result.add_error(f"Duplicate node ID '{node_id}' found.")
+            node_ids.add(node_id)
+
+        # Validate position format
+        position = node.get("position")
+        if position is not None:
+            if not isinstance(position, list) or len(position) != 2:
+                result.add_error(
+                    f"Node '{node.get('name', f'index {i}')}' position must be [x, y] array."
+                )
+
+        # Check for credentials by name (warning)
+        credentials = node.get("credentials", {})
+        for _cred_type, cred_ref in credentials.items():
+            if isinstance(cred_ref, dict) and "name" in cred_ref and "id" not in cred_ref:
+                result.add_warning(
+                    f"Node '{node.get('name', f'index {i}')}' references credential "
+                    f"'{cred_ref.get('name')}' by name. Use 'id' for reliability."
+                )
+
+
+def _validate_connections(workflow: dict[str, Any], result: ValidationResult) -> None:
+    """Validate connections reference existing nodes."""
+    connections = workflow.get("connections")
+    nodes = workflow.get("nodes", [])
+
+    if connections is None:
+        return  # Already reported as missing required field
+
+    if not isinstance(connections, dict):
+        result.add_error("Field 'connections' must be an object.")
+        return
+
+    # Build set of valid node names
+    node_names = {node.get("name") for node in nodes if isinstance(node, dict)}
+
+    # Check each connection source
+    for source_name in connections.keys():
+        if source_name not in node_names:
+            result.add_error(f"Connection source '{source_name}' does not match any node name.")
+
+
+def _check_recommended_settings(workflow: dict[str, Any], result: ValidationResult) -> None:
+    """Check for recommended settings."""
+    settings = workflow.get("settings")
+
+    if settings is None:
+        result.add_warning(
+            "Missing 'settings' field. Recommend adding: " '{"settings": {"executionOrder": "v1"}}'
+        )
+    elif isinstance(settings, dict):
+        if "executionOrder" not in settings:
+            result.add_warning(
+                "Missing 'executionOrder' in settings. Recommend: " '{"executionOrder": "v1"}'
+            )


### PR DESCRIPTION
## Summary

This PR implements Phase 2 of the n8n-mcp-issues.md implementation plan:

- **Workflow Filtering**: Added optional filters to `list_workflows` tool (name_contains, active, tag_ids) with client-side filtering since n8n API v1 lacks server-side support
- **Workflow Validation**: New `validate_workflow` tool with comprehensive pre-submission validation catching forbidden fields, missing requirements, invalid nodes, and connection issues
- **Credential Types Documentation**: New `docs/CREDENTIAL_TYPES.md` with examples of common credential types (httpHeaderAuth, OAuth2, SSH, GitHub, Slack, AWS, databases)

## Changes

### New Files
- `src/n8n_mcp/validator.py` - Validation module with `ValidationResult` class and validators
- `docs/CREDENTIAL_TYPES.md` - Credential type reference documentation

### Modified Files  
- `src/n8n_mcp/client.py` - Extended `list_workflows()` with filtering parameters
- `src/n8n_mcp/server.py` - Added filtering to `list_workflows` tool, new `validate_workflow` tool
- `tests/test_server.py` - 22 new tests for filtering and validation

## Test Results
- **88 tests passing** (22 new)
- **95% code coverage** (exceeds 80% threshold)
- **SonarCloud Quality Gate**: OK
- All code quality checks pass (black, ruff, mypy, pylint, flake8, bandit)

## Test Plan
- [x] All existing tests still pass
- [x] New filtering tests cover name, active status, tags, and combined filters
- [x] Validation tests cover all error conditions (forbidden fields, missing required, invalid nodes)
- [x] Jenkins build passes quality gates
- [x] SonarCloud analysis shows no new issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)