### PR TITLE
docs: update CLAUDE.md with accurate tool count and CM Plan structure

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,51 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+    # Optional: Only run on specific file changes
+    # paths:
+    #   - "src/**/*.ts"
+    #   - "src/**/*.tsx"
+    #   - "src/**/*.js"
+    #   - "src/**/*.jsx"
+
+jobs:
+  claude-review:
+    # Optional: Filter by PR author
+    # if: |
+    #   github.event.pull_request.user.login == 'external-contributor' ||
+    #   github.event.pull_request.user.login == 'new-developer' ||
+    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code Review
+        id: claude-review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
+          plugins: 'code-review@claude-code-plugins'
+          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          allowed_tools: |
+            Bash(gh pr*)
+            Bash(find*)
+            Bash(grep*)
+            Bash(cat*)
+            Bash(ls*)
+            Bash(python3*)
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          # or https://code.claude.com/docs/en/cli-reference for available options
+

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,50 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+      actions: read # Required for Claude to read CI results on PRs
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          # This is an optional setting that allows Claude to read CI results on PRs
+          additional_permissions: |
+            actions: read
+
+          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
+          # prompt: 'Update the pull request description to include a summary of changes.'
+
+          # Optional: Add claude_args to customize behavior and configuration
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          # or https://code.claude.com/docs/en/cli-reference for available options
+          # claude_args: '--allowed-tools Bash(gh pr:*)'
+

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,13 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-n8n-mcp-server is an MCP (Model Context Protocol) server providing 9 tools to interact with the n8n workflow automation platform at n8n.homelab.com. Built with FastMCP and Python 3.11+, it enables Claude Code to manage workflows (CRUD operations), execute workflows, and monitor execution history.
+n8n-mcp-server is an MCP (Model Context Protocol) server providing **30 tools** to interact with the n8n workflow automation platform. Built with FastMCP and Python 3.11+, it enables Claude Code to manage workflows (CRUD, execute, clone, validate), credentials, tags, and executions.
+
+**Key Capabilities:**
+- Workflow CRUD + filtering, cloning, health analysis
+- Credential and tag management
+- Execution history and retry
+- Pre-submission workflow validation
 
 ## **CRITICAL: Development vs Staging**
 
@@ -122,14 +128,14 @@ This interactive command:
 ### Core Components
 
 **src/n8n_mcp/server.py** - FastMCP server entry point
-- Defines 9 MCP tools decorated with `@mcp.tool()` and `@handle_errors`
+- Defines 30 MCP tools decorated with `@mcp.tool()` and `@handle_errors`
 - Loads `.env` from plugin directory (not cwd) to support installed plugin usage
 - Module-level `N8nClient` instance for efficiency (shared across all tool calls)
-- Tools: list_workflows, get_workflow, create_workflow, update_workflow, delete_workflow, activate_workflow, execute_workflow, get_executions, get_execution
+- Tool categories: workflows (13), executions (5), credentials (6), tags (5), health (1)
 
 **src/n8n_mcp/client.py** - N8nClient class
 - Async context manager (`async with`) wrapping httpx for n8n REST API
-- Methods mirror the 9 MCP tools
+- Methods mirror the 30 MCP tools
 - SSL verification disabled (`verify_ssl=False`) for homelab environments
 - Proper cleanup in `__aexit__` and `close()`
 - Internal `_request()` method handles all HTTP errors and returns consistent error dicts
@@ -210,28 +216,25 @@ async def my_tool() -> dict[str, Any]:
     return await client.my_method()
 ```
 
-## Plugin Staging Directory
+## Project Structure (CM Plan)
 
-**Location**: `/home/kviscount.adm@homelab.com/projects/claude-marketplace/plugins/n8n-api/`
+```
+n8n-mcp-server/
+├── .claude-plugin/plugin.json    # Plugin manifest (REQUIRED)
+├── config/mcp.json               # Dev MCP config (uses ${CLAUDE_PLUGIN_ROOT})
+├── skills/n8n-setup/SKILL.md     # Setup skill
+├── commands/                     # Slash commands
+├── agents/                       # Subagents (empty)
+├── hooks/hooks.json              # Event handlers
+├── src/n8n_mcp/                  # MCP server source
+├── tests/                        # pytest tests
+├── docs/                         # Documentation
+├── CHANGELOG.md                  # Version history
+├── pyproject.toml                # Build config
+└── uv.lock                       # Dependency lockfile
+```
 
-**IMPORTANT**: This is the DEPLOYMENT/STAGING directory. Files are copied here from the development directory.
-
-The staging directory contains:
-- `.claude-plugin/plugin.json` - Plugin metadata
-- `.mcp.json` - MCP server configuration
-- `src/` - Source code (copied from development)
-- `skills/` - Skills (copied from development)
-- `commands/` - Commands (copied from development)
-
-**To update staging:**
-1. Make changes in THIS development directory first
-2. Copy updated files to staging directory
-3. Test the plugin from staging
-
-**NEVER:**
-- Create new files directly in staging
-- Edit files in staging without updating development first
-- Use staging as the source of truth
+See `docs/SOFTWARE-CM-PLAN.md` for complete CM specifications.
 
 ## Git Workflow
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ packages = ["src/n8n_mcp"]
 
 [project]
 name = "n8n-mcp-server"
-version = "0.6.6"
+version = "0.7.0b1"
 description = "MCP server providing tools to interact with n8n workflow automation platform"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/n8n_mcp/__init__.py
+++ b/src/n8n_mcp/__init__.py
@@ -5,4 +5,4 @@ Version: 0.1.0
 Created: 2025-11-20
 """
 
-__version__ = "0.6.6"
+__version__ = "0.7.0b1"

--- a/uv.lock
+++ b/uv.lock
@@ -645,7 +645,7 @@ wheels = [
 
 [[package]]
 name = "n8n-mcp-server"
-version = "0.6.6"
+version = "0.7.0b1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary
- Update tool count from 9 to 30 (actual count)
- Add key capabilities summary
- Add tool category breakdown (workflows, executions, credentials, tags, health)
- Replace redundant staging section with CM Plan directory structure
- Reference docs/SOFTWARE-CM-PLAN.md for complete specifications
- Bump version to 0.7.0b1 (beta for CM Plan changes)

## Test plan
- [ ] Verify CLAUDE.md renders correctly
- [ ] Verify tool count matches `grep -c "@mcp.tool()" src/n8n_mcp/server.py`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)