### PR TITLE
docs: Update documentation for v0.7.0b1 release

### DIFF
--- a/.claude/commands/deploy-plugin.md
+++ b/.claude/commands/deploy-plugin.md
@@ -301,7 +301,7 @@ echo "Validating deployment..."
 
 [ -f "$MARKETPLACE/.claude-plugin/plugin.json" ] && echo "plugin.json exists" || echo "plugin.json MISSING"
 [ -f "$MARKETPLACE/.mcp.json" ] && echo ".mcp.json exists" || echo ".mcp.json MISSING"
-[ -f "$MARKETPLACE/src/n8n_mcp/mcp/server.py" ] && echo "server.py exists" || echo "server.py MISSING"
+[ -f "$MARKETPLACE/src/n8n_mcp/server.py" ] && echo "server.py exists" || echo "server.py MISSING"
 [ -f "$MARKETPLACE/pyproject.toml" ] && echo "pyproject.toml exists" || echo "pyproject.toml MISSING"
 [ -d "$MARKETPLACE/config" ] && echo "config/ exists" || echo "config/ MISSING"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## [0.7.0b1] - 2026-01-26
+
+### Changed
+- **Python 3.12**: Upgraded from Python 3.11 to 3.12
+- **Ruff-only linting**: Consolidated Black, Pylint, Flake8 into unified Ruff tool
+- **Documentation**: Updated CLAUDE.md and README.md for new tooling
+
+### Added
+- **Semgrep SAST**: Added security static analysis scanning to CI pipeline
+- **Dependency-Track**: SBOM upload integration for dependency vulnerability monitoring
+
+### Security
+- Enhanced CI pipeline with Semgrep security scanning
+
 ## [0.6.5] - 2025-01-25
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ MCP server providing tools to interact with the n8n workflow automation platform
 
 ## Features
 
-- **28 n8n API tools** for complete workflow automation
+- **30 n8n API tools** for complete workflow automation
 - Full workflow CRUD operations (Create, Read, Update, Delete)
 - Workflow health monitoring and cloning
 - Credential and tag management
@@ -15,7 +15,7 @@ MCP server providing tools to interact with the n8n workflow automation platform
 - SSL/TLS support for homelab environments
 - Complete type hints and documentation
 - Production-ready error handling
-- 99 tests with 94% code coverage
+- 139 tests with comprehensive code coverage
 
 ## Tools
 
@@ -63,22 +63,19 @@ MCP server providing tools to interact with the n8n workflow automation platform
 
 ### Prerequisites
 
-- Python 3.11 or higher
+- Python 3.12 or higher
 - n8n instance with API access (n8n.homelab.com)
 - Claude CLI installed (`curl -sSL https://claude.ai/install | bash`)
 
 ### Setup
 
 ```bash
-cd ~/scripts/n8n-mcp-server
+cd ~/projects/n8n-mcp-server
 
-# Install dependencies using Poetry
-poetry install
-
-# Or using uv
+# Create virtual environment and install
 uv venv
-source .venv/bin/activate
-uv pip install -e .
+source .venv/bin/activate  # or .venv\Scripts\activate on Windows
+uv pip install -e ".[dev]"
 ```
 
 ### Configuration
@@ -158,7 +155,7 @@ pytest tests/test_server.py -v
 
 ```bash
 # Format code
-black src tests
+ruff format src tests
 
 # Lint code
 ruff check src tests
@@ -252,14 +249,14 @@ See [N8N_SERVER_UPDATE_WORKFLOW.md](./docs/N8N_SERVER_UPDATE_WORKFLOW.md) for:
 n8n-mcp-server/
 ├── src/n8n_mcp/
 │   ├── __init__.py       # Package initialization
-│   ├── server.py         # FastMCP server with 28 tools
+│   ├── server.py         # FastMCP server with 30 tools
 │   ├── client.py         # n8n API client wrapper (SSL support)
 │   ├── validator.py      # Workflow validation utilities
 │   ├── models.py         # Pydantic models for n8n data
 │   └── utils.py          # Shared utilities
 ├── tests/
 │   ├── __init__.py
-│   └── test_server.py    # 99 tests with 94% coverage
+│   └── test_server.py    # 139 tests with comprehensive coverage
 ├── docs/
 │   ├── N8N_API_WORKFLOW_CREATION_REPORT.md  # Detailed API research
 │   ├── N8N_SERVER_UPDATE_WORKFLOW.md        # Server update workflow guide
@@ -280,7 +277,7 @@ MIT License - See LICENSE file for details
 Contributions welcome! Please ensure:
 
 - All tests pass (`pytest`)
-- Code is formatted (`black src tests`)
+- Code is formatted (`ruff format src tests`)
 - Code is linted (`ruff check src tests`)
 - Type hints are provided (`mypy src`)
 - Documentation is updated

--- a/docs/KNOWN_LIMITATIONS.md
+++ b/docs/KNOWN_LIMITATIONS.md
@@ -2,7 +2,7 @@
 
 This document describes limitations imposed by the n8n API that cannot be fixed in the MCP layer. These are upstream API issues that require workarounds.
 
-**Last Updated**: 2026-01-13
+**Last Updated**: 2026-01-26
 **n8n Version Tested**: 1.114.3
 
 ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ name = "n8n-mcp-server"
 version = "0.7.0b1"
 description = "MCP server providing tools to interact with n8n workflow automation platform"
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 license = {text = "MIT"}
 authors = [
     {name = "Kent Viscount", email = "visccyberacct@gmail.com"}
@@ -21,8 +21,8 @@ classifiers = [
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 
 dependencies = [
@@ -37,34 +37,27 @@ dev = [
     "pytest>=8.0.0",
     "pytest-asyncio>=0.23.0",
     "pytest-cov>=4.1.0",
-    "black>=24.0.0",
     "ruff>=0.3.0",
     "mypy>=1.8.0",
-    "pylint>=3.0.0",
-    "flake8>=7.0.0",
     "bandit>=1.7.0",
 ]
 
 [project.scripts]
 n8n-mcp-server = "n8n_mcp.server:main"
 
-[tool.black]
-line-length = 100
-target-version = ["py311"]
-
 [tool.ruff]
 line-length = 100
-target-version = "py311"
+target-version = "py312"
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "N", "W", "B", "C4", "UP"]
-ignore = ["E501"]  # Line too long (handled by black)
+ignore = ["E501"]  # Line too long (handled by ruff format)
 
 [tool.ruff.lint.per-file-ignores]
 "src/n8n_mcp/models.py" = ["N815"]  # Allow mixedCase for n8n API field names
 
 [tool.mypy]
-python_version = "3.11"
+python_version = "3.12"
 strict = true
 warn_return_any = true
 warn_unused_configs = true

--- a/src/n8n_mcp/utils.py
+++ b/src/n8n_mcp/utils.py
@@ -8,13 +8,10 @@ Created: 2025-11-22
 import json
 from collections.abc import Callable
 from functools import wraps
-from typing import Any, TypeVar, cast
-
-# Type variable for generic decorator
-F = TypeVar("F", bound=Callable[..., Any])
+from typing import Any, cast
 
 
-def handle_errors(func: F) -> F:
+def handle_errors[F: Callable[..., Any]](func: F) -> F:
     """Decorator to handle errors in MCP tool functions.
 
     Catches all exceptions and returns them as error dictionaries


### PR DESCRIPTION
## Summary
- Update README.md with accurate tool count, test count, and Python version
- Add v0.7.0b1 release notes to CHANGELOG.md
- Update pyproject.toml for Python 3.12 and Ruff-only tooling
- Fix minor issues in supporting documentation

## Changes

### README.md
- Tool count: 28 → 30
- Test count: 99 → 139
- Python requirement: 3.11 → 3.12
- Replace `black` with `ruff format` in code quality section
- Update project structure to reflect accurate counts

### CHANGELOG.md
- Add v0.7.0b1 release entry with CI pipeline modernization details

### pyproject.toml
- `requires-python`: >=3.11 → >=3.12
- Remove deprecated dev dependencies: black, pylint, flake8
- Update Ruff target-version to py312
- Update mypy python_version to 3.12
- Update classifiers for Python 3.12/3.13

### docs/KNOWN_LIMITATIONS.md
- Update last modified date

### .claude/commands/deploy-plugin.md
- Fix incorrect server.py path reference

## Test Plan
- [x] All documentation changes are consistent
- [x] pyproject.toml validates correctly
- [x] No broken references or paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)